### PR TITLE
Add partition reallocation strategy to data cleanup DAG

### DIFF
--- a/dags/data_cleanup_dag.py
+++ b/dags/data_cleanup_dag.py
@@ -2,39 +2,125 @@
 Implements a retention policy by dropping expired partitions
 
 A detailed tutorial is available at https://community.crate.io/t/cratedb-and-apache-airflow-implementation-of-data-retention-policy/913
+
+Prerequisites
+-------------
+In CrateDB, tables for storing retention policies need to be created once manually.
+See the file setup/data_cleanup_schema.sql in this repository.
 """
 import datetime
 import json
+import logging
+from pathlib import Path
 from airflow import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.hooks.postgres_hook import PostgresHook
 from airflow.operators.python_operator import PythonOperator
 
 
-def get_policies(sql):
+def get_policies(logical_date):
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
+    sql = Path('include/data_cleanup_retrieve_policies.sql').read_text().format(date=logical_date)
     records = pg_hook.get_records(sql=sql)
-    retention_policies = json.dumps(records)
-    return retention_policies
+
+    return json.dumps(records)
 
 
-def delete_partitions(ti):
+def delete_partition(partition):
+    logging.info("Deleting partition %s = %s for table %s",
+                 partition["column_name"],
+                 partition["partition_value"],
+                 partition["table_fqn"],
+    )
+
+    PostgresOperator(
+        task_id="delete_from_{table}_{partition}_{value}".format(
+            table=partition["table_fqn"],
+            partition=partition["column_name"],
+            value=partition["partition_value"],
+        ),
+        postgres_conn_id="cratedb_connection",
+        sql=Path('include/data_cleanup_delete.sql').read_text().format(
+            table=partition["table_fqn"],
+            column=partition["column_name"],
+            value=partition["partition_value"],
+        ),
+    ).execute(dict())
+
+
+def reallocate_partition(partition):
+    logging.info("Reallocating partition %s = %s for table %s to %s = %s",
+                 partition["column_name"],
+                 partition["partition_value"],
+                 partition["table_fqn"],
+                 partition["reallocation_attribute_name"],
+                 partition["reallocation_attribute_value"],
+    )
+
+    # Reallocate the partition
+    PostgresOperator(
+        task_id="reallocate_{table}_{partition}_{value}".format(
+            table=partition["table_fqn"],
+            partition=partition["column_name"],
+            value=partition["partition_value"],
+        ),
+        postgres_conn_id="cratedb_connection",
+        sql=Path('include/data_cleanup_reallocate.sql').read_text().format(
+            table=partition["table_fqn"],
+            column=partition["column_name"],
+            value=partition["partition_value"],
+            attribute_name=partition["reallocation_attribute_name"],
+            attribute_value=partition["reallocation_attribute_value"],
+        ),
+    ).execute(dict())
+
+    # Update tracking information. As we process partitions in ascending order
+    # by the partition value, it is safe to always save the current value.
+    PostgresOperator(
+        task_id="reallocate_track_{table}_{partition}_{value}".format(
+            table=partition["table_fqn"],
+            partition=partition["column_name"],
+            value=partition["partition_value"],
+        ),
+        postgres_conn_id="cratedb_connection",
+        sql=Path('include/data_cleanup_reallocate_tracking.sql').read_text().format(
+            table=partition["table_name"],
+            schema=partition["schema_name"],
+            partition_value=partition["partition_value"],
+        ),
+    ).execute(dict())
+
+def process_partition(partition):
+    if partition["strategy"] == 'delete':
+        delete_partition(partition)
+    elif partition["strategy"] == 'reallocate':
+        reallocate_partition(partition)
+    else:
+        logging.warning("Ignoring unknown strategy \"%s\" for table %s",
+                        partition["strategy"],
+                        partition["table_fqn"],
+        )
+
+
+def map_policy(policy):
+    return {
+        "schema_name": policy[0],
+        "table_name": policy[1],
+        "table_fqn": policy[2],
+        "column_name": policy[3],
+        "partition_value": policy[4],
+        "strategy": policy[5],
+        "reallocation_attribute_name": policy[6],
+        "reallocation_attribute_value": policy[7],
+    }
+
+
+def process_partitions(ti):
     retention_policies = ti.xcom_pull(task_ids="retrieve_retention_policies")
     policies_obj = json.loads(retention_policies)
+
     for policy in policies_obj:
-        table_name = policy[0]
-        column_name = policy[1]
-        partition_value = policy[2]
-        PostgresOperator(
-            task_id="delete_from_{table}".format(table=str(table_name)),
-            postgres_conn_id="cratedb_connection",
-            sql="DELETE FROM %(table)s WHERE %(column)s=%(value)s",
-            parameters={
-                "table": str(table_name),
-                "column": str(column_name),
-                "value": partition_value,
-            },
-        ).execute(dict())
+        process_partition(map_policy(policy))
 
 
 with DAG(
@@ -47,17 +133,13 @@ with DAG(
         task_id="retrieve_retention_policies",
         python_callable=get_policies,
         op_kwargs={
-            "sql": """ SELECT QUOTE_IDENT(p.table_schema) || '.' || QUOTE_IDENT(p.table_name) as fqn,
-                        r.partition_column, p.values[r.partition_column]
-                       FROM information_schema.table_partitions p JOIN doc.retention_policies r ON p.table_schema = r.table_schema
-                       AND p.table_name = r.table_name
-                       AND p.values[r.partition_column] < {date}::TIMESTAMP - r.retention_period;"""
-            .format(date="{{ ds }}")
+            "logical_date": "{{ ds }}",
         },
     )
+
     apply_policies = PythonOperator(
         task_id="apply_data_retention_policies",
-        python_callable=delete_partitions,
+        python_callable=process_partitions,
         provide_context=True,
         op_kwargs={},
     )

--- a/include/data_cleanup_delete.sql
+++ b/include/data_cleanup_delete.sql
@@ -1,0 +1,1 @@
+DELETE FROM {table} WHERE {column} = {value};

--- a/include/data_cleanup_reallocate.sql
+++ b/include/data_cleanup_reallocate.sql
@@ -1,0 +1,1 @@
+ALTER TABLE {table} PARTITION ({column} = {value}) SET ("routing.allocation.require.{attribute_name}" = '{attribute_value}');

--- a/include/data_cleanup_reallocate_tracking.sql
+++ b/include/data_cleanup_reallocate_tracking.sql
@@ -1,0 +1,1 @@
+INSERT INTO doc.retention_policy_tracking VALUES ('{schema}', '{table}', 'reallocate', {partition_value}) ON CONFLICT (table_name, table_schema, strategy) DO UPDATE SET last_partition_value = excluded.last_partition_value;

--- a/include/data_cleanup_retrieve_policies.sql
+++ b/include/data_cleanup_retrieve_policies.sql
@@ -1,0 +1,23 @@
+SELECT QUOTE_IDENT(p.table_schema),
+       QUOTE_IDENT(p.table_name),
+       QUOTE_IDENT(p.table_schema) || '.' || QUOTE_IDENT(p.table_name),
+       QUOTE_IDENT(r.partition_column),
+       TRY_CAST(p.values[r.partition_column] AS BIGINT),
+       r.strategy,
+       reallocation_attribute_name,
+       reallocation_attribute_value
+FROM information_schema.table_partitions p
+JOIN doc.retention_policies r ON p.table_schema = r.table_schema
+  AND p.table_name = r.table_name
+  AND p.values[r.partition_column] < '{date}'::TIMESTAMP - r.retention_period
+LEFT JOIN doc.retention_policy_tracking t ON t.table_schema = p.table_schema
+  AND t.table_name = p.table_name
+WHERE r.strategy = 'delete'
+  OR (
+    r.strategy = 'reallocate'
+      AND (
+        t.last_partition_value IS NULL
+        OR p.values[r.partition_column] > t.last_partition_value
+      )
+  )
+ORDER BY 5 ASC;

--- a/setup/data_cleanup_schema.sql
+++ b/setup/data_cleanup_schema.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS doc.retention_policies (
+   "table_schema" TEXT,
+   "table_name" TEXT,
+   "partition_column" TEXT NOT NULL,
+   "retention_period" INTEGER NOT NULL,
+   "reallocation_attribute_name" TEXT,
+   "reallocation_attribute_value" TEXT,
+   "strategy" TEXT NOT NULL,
+   PRIMARY KEY ("table_schema", "table_name", "strategy")
+)
+CLUSTERED INTO 1 SHARDS;
+
+CREATE TABLE IF NOT EXISTS doc.retention_policy_tracking (
+   "table_schema" TEXT,
+   "table_name" TEXT,
+   "strategy" TEXT,
+   "last_partition_value" TIMESTAMP WITH TIME ZONE NOT NULL,
+   PRIMARY KEY (table_schema, table_name, strategy)
+)
+CLUSTERED INTO 1 SHARDS;


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
* Extend `retention_policies` table to accommodate both `delete`/`reallocate` strategies
* Added the `reallocate` strategy to the Data Cleanup DAG

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
