### PR TITLE
Update Airflow to 2.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/ap-airflow:2.2.3-2-onbuild
+FROM quay.io/astronomer/ap-airflow:2.2.4-1-onbuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/ap-airflow:2.2.4-1-onbuild
+FROM quay.io/astronomer/ap-airflow:2.2.4-3-onbuild

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 beautifulsoup4==4.10.0
-pandas==1.4.0
+# Restrict pandas version to align with the requirements of some Airflow provider packages.
+# Currently apache-airflow-providers-google and apache-airflow-providers-amazon, which we
+# both don't use, but they are bundled with Airflow by default.
+pandas<1.4,>=0.17.1
 requests==2.27.1
 yfinance==0.1.70

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
             "pylint==2.12.2",
         ],
         "testing": [
-            "pytest==7.0.1",
+            "pytest==7.1.0",
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "apache-airflow==2.2.4",
-        "apache-airflow-providers-postgres==3.0.0",
+        "apache-airflow-providers-postgres==4.0.0",
     ],
     extras_require={
         "develop": [

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,15 @@ setup(
     packages=find_packages(),
     python_requires=">=3.8",
     install_requires=[
-        "apache-airflow==2.2.3",
-        "apache-airflow-providers-postgres==2.4.0",
+        "apache-airflow==2.2.4",
+        "apache-airflow-providers-postgres==3.0.0",
     ],
     extras_require={
         "develop": [
             "pylint==2.12.2",
         ],
         "testing": [
-            "pytest==6.2.5",
+            "pytest==7.0.1",
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
             "pylint==2.12.2",
         ],
         "testing": [
-            "pytest==7.1.0",
+            "pytest==7.1.1",
         ],
     },
 )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Update Airflow to the latest minor release. Also align our dependencies accordingly, as some bundled provider packages aren't compatible yet with pandas 1.4.0.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
