### PR TITLE
Update Airflow to 2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/ap-airflow:2.2.5-1-onbuild
+FROM quay.io/astronomer/ap-airflow:2.3.0-1-onbuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/ap-airflow:2.3.0-1-onbuild
+FROM quay.io/astronomer/ap-airflow:2.3.1-1-onbuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/ap-airflow:2.3.1-1-onbuild
+FROM quay.io/astronomer/astro-runtime:5.0.2

--- a/README.md
+++ b/README.md
@@ -34,18 +34,16 @@ The project directory has the following file structure:
 
 ```
   ├── dags # directory containing all DAGs
-  │   ├── config # configuration files used to parameterize DAGs
   ├── include # additional files which are used in DAGs
   ├── .astro # project settings
   ├── Dockerfile # runtime overrides for Astronomer Docker image
-  ├── include # other project files
   ├── packages.txt # specification of OS-level packages
   ├── plugins # custom or community Airflow plugins
   ├── setup # additional setup-related scripts/database schemas
   └── requirements.txt # specification of Python packages
 ```
 
-In the `dags` directory you can find the specification of all DAGs for our examples.
+In the [dags](dags) directory you can find the specification of all DAGs for our examples.
 Each DAG is accompanied by a tutorial:
 
 * [table_export_dag.py](dags/table_export_dag.py) ([tutorial](https://community.crate.io/t/cratedb-and-apache-airflow-automating-data-export-to-s3/901)): performs a daily export of table data to a remote filesystem (in our case S3)

--- a/dags/data_retention_delete_dag.py
+++ b/dags/data_retention_delete_dag.py
@@ -27,9 +27,8 @@ def generate_sql(policy):
 @task
 def get_policies(ds=None):
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
-    sql = Path('include/data_retention_retrieve_delete_policies.sql') \
-            .read_text(encoding="utf-8").format(date=ds)
-    return pg_hook.get_records(sql=sql)
+    sql = Path('include/data_retention_retrieve_delete_policies.sql')
+    return pg_hook.get_records(sql=sql.read_text(encoding="utf-8"), parameters={"day": ds})
 
 @dag(
     start_date=pendulum.datetime(2021, 11, 19, tz="UTC"),

--- a/dags/data_retention_delete_dag.py
+++ b/dags/data_retention_delete_dag.py
@@ -14,18 +14,18 @@ from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.decorators import dag, task
 
-# Generate DROP statment for a given partition
 @task
 def generate_sql(policy):
+    """Generate DROP statment for a given partition"""
     return Path('include/data_retention_delete.sql') \
         .read_text(encoding="utf-8").format(table_fqn=policy[0],
                                             column=policy[1],
                                             value=policy[2],
                                            )
 
-# Retrieve all partitions effected by a policy
 @task
 def get_policies(ds=None):
+    """Retrieve all partitions effected by a policy"""
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
     sql = Path('include/data_retention_retrieve_delete_policies.sql')
     return pg_hook.get_records(sql=sql.read_text(encoding="utf-8"), parameters={"day": ds})

--- a/dags/data_retention_delete_dag.py
+++ b/dags/data_retention_delete_dag.py
@@ -8,76 +8,41 @@ Prerequisites
 In CrateDB, tables for storing retention policies need to be created once manually.
 See the file setup/data_retention_schema.sql in this repository.
 """
-import json
-import logging
 from pathlib import Path
 import pendulum
-from airflow import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.operators.python import PythonOperator
+from airflow.decorators import dag, task
 
+# Generate DROP statment for a given partition
+@task
+def generate_sql(policy):
+    return Path('include/data_retention_delete.sql') \
+        .read_text(encoding="utf-8").format(table=policy[0],
+                                            column=policy[1],
+                                            value=policy[2],
+                                           )
 
-def get_policies(logical_date):
+# Retrieve all partitions effected by a policy
+@task
+def get_policies(ds=None):
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
     sql = Path('include/data_retention_retrieve_delete_policies.sql') \
-              .read_text(encoding="utf-8").format(date=logical_date)
-    records = pg_hook.get_records(sql=sql)
+            .read_text(encoding="utf-8").format(date=ds)
+    return pg_hook.get_records(sql=sql)
 
-    return json.dumps(records)
-
-
-def map_policy(policy):
-    return {
-        "table_fqn": policy[0],
-        "column_name": policy[1],
-        "partition_value": policy[2],
-    }
-
-
-def delete_partitions(ti):
-    retention_policies = ti.xcom_pull(task_ids="retrieve_retention_policies")
-    policies_obj = json.loads(retention_policies)
-
-    for policy in policies_obj:
-        partition = map_policy(policy)
-
-        logging.info("Deleting partition %s = %s for table %s",
-                     partition["column_name"],
-                     partition["partition_value"],
-                     partition["table_fqn"],
-        )
-
-        PostgresOperator(
-            task_id=f"delete_from_{partition['table_fqn']}" \
-                    f"_{partition['column_name']}_{partition['partition_value']}",
-            postgres_conn_id="cratedb_connection",
-            sql=Path('include/data_retention_delete.sql').read_text(encoding="utf-8").format(
-                table=partition["table_fqn"],
-                column=partition["column_name"],
-                value=partition["partition_value"],
-            ),
-        ).execute({})
-
-
-with DAG(
-    dag_id="data-retention-delete-dag",
+@dag(
     start_date=pendulum.datetime(2021, 11, 19, tz="UTC"),
     schedule_interval="@daily",
     catchup=False,
-) as dag:
-    get_policies = PythonOperator(
-        task_id="retrieve_retention_policies",
-        python_callable=get_policies,
-        op_kwargs={
-            "logical_date": "{{ ds }}",
-        },
-    )
+)
+def data_retention_delete():
+    sql_statements = generate_sql.expand(policy=get_policies())
 
-    apply_policies = PythonOperator(
-        task_id="apply_data_retention_policies",
-        python_callable=delete_partitions,
-        op_kwargs={},
-    )
+    PostgresOperator.partial(
+        task_id="delete_partition",
+        postgres_conn_id="cratedb_connection",
+    ).expand(sql=sql_statements)
 
-    get_policies >> apply_policies
+
+data_retention_delete_dag = data_retention_delete()

--- a/dags/data_retention_delete_dag.py
+++ b/dags/data_retention_delete_dag.py
@@ -18,7 +18,7 @@ from airflow.decorators import dag, task
 @task
 def generate_sql(policy):
     return Path('include/data_retention_delete.sql') \
-        .read_text(encoding="utf-8").format(table=policy[0],
+        .read_text(encoding="utf-8").format(table_fqn=policy[0],
                                             column=policy[1],
                                             value=policy[2],
                                            )

--- a/dags/data_retention_reallocate_dag.py
+++ b/dags/data_retention_reallocate_dag.py
@@ -14,16 +14,16 @@ from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.decorators import dag, task
 
-# Retrieve all partitions effected by a policy
 @task
 def get_policies(ds=None):
+    """Retrieve all partitions effected by a policy"""
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
     sql = Path('include/data_retention_retrieve_reallocate_policies.sql')
     return pg_hook.get_records(sql=sql.read_text(encoding="utf-8"), parameters={"day": ds})
 
-# Map index-based policy to readable dict structure
 @task
 def map_policy(policy):
+    """Map index-based policy to readable dict structure"""
     return {
         "schema": policy[0],
         "table": policy[1],
@@ -34,9 +34,9 @@ def map_policy(policy):
         "attribute_value": policy[6],
     }
 
-# Generate SQL for reallocation
 @task
 def generate_sql_reallocate(policy):
+    """Generate SQL for reallocation"""
     return Path('include/data_retention_reallocate.sql').read_text(encoding="utf-8") \
         .format(**policy)
 

--- a/dags/data_retention_reallocate_dag.py
+++ b/dags/data_retention_reallocate_dag.py
@@ -1,106 +1,67 @@
 """
 Implements a retention policy by reallocating cold partitions
 
+A detailed tutorial is available at https://community.crate.io/t/cratedb-and-apache-airflow-building-a-hot-cold-storage-data-retention-policy/934
+
 Prerequisites
 -------------
 In CrateDB, tables for storing retention policies need to be created once manually.
 See the file setup/data_retention_schema.sql in this repository.
 """
-import json
-import logging
 from pathlib import Path
 import pendulum
-from airflow import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.operators.python import PythonOperator
+from airflow.decorators import dag, task
 
-
-def get_policies(logical_date):
+# Retrieve all partitions effected by a policy
+@task
+def get_policies(ds=None):
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
     sql = Path('include/data_retention_retrieve_reallocate_policies.sql') \
-              .read_text(encoding="utf-8").format(date=logical_date)
-    records = pg_hook.get_records(sql=sql)
+            .read_text(encoding="utf-8").format(date=ds)
+    return pg_hook.get_records(sql=sql)
 
-    return json.dumps(records)
-
-
-def reallocate_partition(partition):
-    logging.info("Reallocating partition %s = %s for table %s to %s = %s",
-                 partition["column_name"],
-                 partition["partition_value"],
-                 partition["table_fqn"],
-                 partition["reallocation_attribute_name"],
-                 partition["reallocation_attribute_value"],
+# Generate SQL for reallocation
+@task
+def generate_sql_reallocate(policy):
+    return Path('include/data_retention_reallocate.sql').read_text(encoding="utf-8").format(
+        table=policy[2],
+        column=policy[3],
+        value=policy[4],
+        attribute_name=policy[5],
+        attribute_value=policy[6],
     )
 
-    # Reallocate the partition
-    PostgresOperator(
-        task_id=f"reallocate_{partition['table_fqn']}" \
-                f"_{partition['column_name']}_{partition['partition_value']}",
-        postgres_conn_id="cratedb_connection",
-        sql=Path('include/data_retention_reallocate.sql').read_text(encoding="utf-8").format(
-            table=partition["table_fqn"],
-            column=partition["column_name"],
-            value=partition["partition_value"],
-            attribute_name=partition["reallocation_attribute_name"],
-            attribute_value=partition["reallocation_attribute_value"],
-        ),
-    ).execute({})
+# Generate SQL for tracking entry
+@task
+def generate_sql_tracking(policy):
+    return Path('include/data_retention_reallocate_tracking.sql').read_text(encoding="utf-8") \
+            .format(schema=policy[0],
+                    table=policy[1],
+                    partition_value=policy[4],
+                   )
 
-    # Update tracking information. As we process partitions in ascending order
-    # by the partition value, it is safe to always save the current value.
-    PostgresOperator(
-        task_id=f"reallocate_track_{partition['table_fqn']}" \
-                f"_{partition['column_name']}_{partition['partition_value']}",
-        postgres_conn_id="cratedb_connection",
-        sql=Path('include/data_retention_reallocate_tracking.sql') \
-                .read_text(encoding="utf-8") \
-                .format(table=partition["table_name"],
-                        schema=partition["schema_name"],
-                        partition_value=partition["partition_value"],
-                        ),
-    ).execute({})
-
-
-def map_policy(policy):
-    return {
-        "schema_name": policy[0],
-        "table_name": policy[1],
-        "table_fqn": policy[2],
-        "column_name": policy[3],
-        "partition_value": policy[4],
-        "reallocation_attribute_name": policy[5],
-        "reallocation_attribute_value": policy[6],
-    }
-
-
-def reallocate_partitions(ti):
-    retention_policies = ti.xcom_pull(task_ids="retrieve_retention_policies")
-    policies_obj = json.loads(retention_policies)
-
-    for policy in policies_obj:
-        reallocate_partition(map_policy(policy))
-
-
-with DAG(
-    dag_id="data-retention-reallocate-dag",
+@dag(
     start_date=pendulum.datetime(2021, 11, 19, tz="UTC"),
     schedule_interval="@daily",
     catchup=False,
-) as dag:
-    get_policies = PythonOperator(
-        task_id="retrieve_retention_policies",
-        python_callable=get_policies,
-        op_kwargs={
-            "logical_date": "{{ ds }}",
-        },
-    )
+)
+def data_retention_reallocate():
+    policies = get_policies()
+    sql_statements_reallocate = generate_sql_reallocate.expand(policy=policies)
+    sql_statements_tracking = generate_sql_tracking.expand(policy=policies)
 
-    apply_policies = PythonOperator(
-        task_id="apply_data_retention_policies",
-        python_callable=reallocate_partitions,
-        op_kwargs={},
-    )
+    reallocate = PostgresOperator.partial(
+        task_id="reallocate_partitions",
+        postgres_conn_id="cratedb_connection",
+    ).expand(sql=sql_statements_reallocate)
 
-    get_policies >> apply_policies
+    track = PostgresOperator.partial(
+        task_id="add_tracking_information",
+        postgres_conn_id="cratedb_connection",
+    ).expand(sql=sql_statements_tracking)
+
+    reallocate >> track
+
+data_retention_reallocate_dag = data_retention_reallocate()

--- a/dags/data_retention_reallocate_dag.py
+++ b/dags/data_retention_reallocate_dag.py
@@ -18,9 +18,8 @@ from airflow.decorators import dag, task
 @task
 def get_policies(ds=None):
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
-    sql = Path('include/data_retention_retrieve_reallocate_policies.sql') \
-            .read_text(encoding="utf-8").format(date=ds)
-    return pg_hook.get_records(sql=sql)
+    sql = Path('include/data_retention_retrieve_reallocate_policies.sql')
+    return pg_hook.get_records(sql=sql.read_text(encoding="utf-8"), parameters={"day": ds})
 
 # Generate SQL for reallocation
 @task

--- a/dags/data_retention_snapshot_dag.py
+++ b/dags/data_retention_snapshot_dag.py
@@ -14,16 +14,16 @@ from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.decorators import dag, task
 
-# Retrieve all partitions effected by a policy
 @task
 def get_policies(ds=None):
+    """Retrieve all partitions effected by a policy"""
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
     sql = Path('include/data_retention_retrieve_snapshot_policies.sql')
     return pg_hook.get_records(sql=sql.read_text(encoding="utf-8"), parameters={"day": ds})
 
-# Map index-based policy to readable dict structure
 @task
 def map_policy(policy):
+    """Map index-based policy to readable dict structure"""
     return {
         "schema": policy[0],
         "table": policy[1],
@@ -33,9 +33,9 @@ def map_policy(policy):
         "target_repository_name": policy[5],
     }
 
-# Generate SQL statment for a given partition
 @task
 def generate_sql(query_file, policy):
+    """Generate SQL statment for a given partition"""
     return Path(query_file).read_text(encoding="utf-8").format(**policy)
 
 @dag(

--- a/dags/data_retention_snapshot_dag.py
+++ b/dags/data_retention_snapshot_dag.py
@@ -18,9 +18,8 @@ from airflow.decorators import dag, task
 @task
 def get_policies(ds=None):
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
-    sql = Path('include/data_retention_retrieve_snapshot_policies.sql') \
-            .read_text(encoding="utf-8").format(date=ds)
-    return pg_hook.get_records(sql=sql)
+    sql = Path('include/data_retention_retrieve_snapshot_policies.sql')
+    return pg_hook.get_records(sql=sql.read_text(encoding="utf-8"), parameters={"day": ds})
 
 # Generate DROP statment for a given partition
 @task

--- a/dags/data_retention_snapshot_dag.py
+++ b/dags/data_retention_snapshot_dag.py
@@ -1,98 +1,68 @@
 """
 Implements a retention policy by snapshotting expired partitions to a repository
 
+A detailed tutorial is available at https://community.crate.io/t/cratedb-and-apache-airflow-building-a-data-retention-policy-using-external-snapshot-repositories/1001
+
 Prerequisites
 -------------
 In CrateDB, tables for storing retention policies need to be created once manually.
 See the file setup/data_retention_schema.sql in this repository.
 """
-import json
-import logging
 from pathlib import Path
 import pendulum
-from airflow import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.operators.python import PythonOperator
+from airflow.decorators import dag, task
 
-
-def get_policies(logical_date):
+# Retrieve all partitions effected by a policy
+@task
+def get_policies(ds=None):
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
     sql = Path('include/data_retention_retrieve_snapshot_policies.sql') \
-              .read_text(encoding="utf-8").format(date=logical_date)
-    records = pg_hook.get_records(sql=sql)
+            .read_text(encoding="utf-8").format(date=ds)
+    return pg_hook.get_records(sql=sql)
 
-    return json.dumps(records)
+# Generate DROP statment for a given partition
+@task
+def generate_sql_delete(policy):
+    return Path('include/data_retention_delete.sql') \
+        .read_text(encoding="utf-8").format(table=policy[2],
+                                            column=policy[3],
+                                            value=policy[4],
+                                           )
 
+# Generate DROP statment for a given partition
+@task
+def generate_sql_snapshot(policy):
+    return Path('include/data_retention_snapshot.sql').read_text(encoding="utf-8") \
+            .format(repository_name=policy[5],
+                    table_schema=policy[0],
+                    table_name=policy[1],
+                    table_fqn=policy[2],
+                    partition_column=policy[3],
+                    partition_value=policy[4],
+                   )
 
-def map_policy(policy):
-    return {
-        "table_schema": policy[0],
-        "table_name": policy[1],
-        "table_fqn": policy[2],
-        "column_name": policy[3],
-        "partition_value": policy[4],
-        "target_repository_name": policy[5],
-    }
-
-
-def snapshot_partitions(ti):
-    retention_policies = ti.xcom_pull(task_ids="retrieve_retention_policies")
-    policies_obj = json.loads(retention_policies)
-
-    for policy in policies_obj:
-        partition = map_policy(policy)
-
-        logging.info("Snapshoting partition %s = %s for table %s",
-                     partition["column_name"],
-                     partition["partition_value"],
-                     partition["table_fqn"],
-        )
-
-        PostgresOperator(
-            task_id=f"snapshot_{partition['table_fqn']}" \
-                    f"_{partition['column_name']}_{partition['partition_value']}",
-            postgres_conn_id="cratedb_connection",
-            sql=Path('include/data_retention_snapshot.sql').read_text(encoding="utf-8").format(
-                repository_name=partition["target_repository_name"],
-                table_schema=partition["table_schema"],
-                table_name=partition["table_name"],
-                table_fqn=partition["table_fqn"],
-                partition_column=partition["column_name"],
-                partition_value=partition["partition_value"],
-            ),
-        ).execute({})
-
-        PostgresOperator(
-            task_id=f"delete_{partition['table_fqn']}" \
-                    f"_{partition['column_name']}_{partition['partition_value']}",
-            postgres_conn_id="cratedb_connection",
-            sql=Path('include/data_retention_delete.sql').read_text(encoding="utf-8").format(
-                table=partition["table_fqn"],
-                column=partition["column_name"],
-                value=partition["partition_value"],
-            ),
-        ).execute({})
-
-
-with DAG(
-    dag_id="data-retention-snapshot-dag",
-    start_date=pendulum.datetime(2022, 1, 31, tz="UTC"),
+@dag(
+    start_date=pendulum.datetime(2021, 11, 19, tz="UTC"),
     schedule_interval="@daily",
     catchup=False,
-) as dag:
-    get_policies = PythonOperator(
-        task_id="retrieve_retention_policies",
-        python_callable=get_policies,
-        op_kwargs={
-            "logical_date": "{{ ds }}",
-        },
-    )
+)
+def data_retention_snapshot():
+    policies = get_policies()
+    sql_statements_snapshot = generate_sql_snapshot.expand(policy=policies)
+    sql_statements_delete = generate_sql_delete.expand(policy=policies)
 
-    apply_policies = PythonOperator(
-        task_id="apply_data_retention_policies",
-        python_callable=snapshot_partitions,
-        op_kwargs={},
-    )
+    reallocate = PostgresOperator.partial(
+        task_id="snapshot_partitions",
+        postgres_conn_id="cratedb_connection",
+    ).expand(sql=sql_statements_snapshot)
 
-    get_policies >> apply_policies
+    delete = PostgresOperator.partial(
+        task_id="delete_partitions",
+        postgres_conn_id="cratedb_connection",
+    ).expand(sql=sql_statements_delete)
+
+    reallocate >> delete
+
+data_retention_snapshot_dag = data_retention_snapshot()

--- a/dags/financial_data_dag.py
+++ b/dags/financial_data_dag.py
@@ -19,7 +19,7 @@ from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.decorators import dag, task
 
 def get_sp500_ticker_symbols():
-    "Extracts S&P 500 companies' tickers from the S&P 500's wikipedia page"
+    """Extracts S&P 500 companies' tickers from the S&P 500's wikipedia page"""
 
     # Getting the html code from S&P 500 wikipedia page
     url = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
@@ -45,7 +45,7 @@ def get_sp500_ticker_symbols():
 
 @task(execution_timeout=datetime.timedelta(minutes=3))
 def download_yfinance_data(ds=None):
-    "downloads Adjusted Close data from S&P 500 companies"
+    """Downloads Adjusted Close data from S&P 500 companies"""
 
     tickers = get_sp500_ticker_symbols()
     data = yf.download(tickers, start=ds)['Adj Close']
@@ -53,7 +53,7 @@ def download_yfinance_data(ds=None):
 
 @task(execution_timeout=datetime.timedelta(minutes=3))
 def prepare_data(string_data):
-    "creates a list of dictionaries with clean data values"
+    """Creates a list of dictionaries with clean data values"""
 
     # transforming to dataframe for easier manipulation
     df = pd.DataFrame.from_dict(json.loads(string_data), orient='index')

--- a/dags/table_export_dag.py
+++ b/dags/table_export_dag.py
@@ -8,7 +8,7 @@ import pendulum
 from airflow import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.utils.task_group import TaskGroup
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.models.baseoperator import chain
 from include.table_exports import TABLES
 
@@ -19,8 +19,8 @@ with DAG(
     schedule_interval="@daily",
     catchup=False,
 ) as dag:
-    start = DummyOperator(task_id='start')
-    end = DummyOperator(task_id='end')
+    start = EmptyOperator(task_id='start')
+    end = EmptyOperator(task_id='end')
     with TaskGroup(group_id='table_exports') as tg1:
         for export_table in TABLES:
             PostgresOperator(

--- a/include/data_retention_delete.sql
+++ b/include/data_retention_delete.sql
@@ -1,1 +1,1 @@
-DELETE FROM {table} WHERE {column} = {value};
+DELETE FROM {table_fqn} WHERE {column} = {value};

--- a/include/data_retention_reallocate.sql
+++ b/include/data_retention_reallocate.sql
@@ -1,1 +1,1 @@
-ALTER TABLE {table} PARTITION ({column} = {value}) SET ("routing.allocation.require.{attribute_name}" = '{attribute_value}');
+ALTER TABLE {table_fqn} PARTITION ({column} = {value}) SET ("routing.allocation.require.{attribute_name}" = '{attribute_value}');

--- a/include/data_retention_reallocate_tracking.sql
+++ b/include/data_retention_reallocate_tracking.sql
@@ -1,1 +1,1 @@
-INSERT INTO doc.retention_policy_tracking VALUES ('{schema}', '{table}', 'reallocate', {partition_value}) ON CONFLICT (table_name, table_schema, strategy) DO UPDATE SET last_partition_value = excluded.last_partition_value;
+INSERT INTO doc.retention_policy_tracking VALUES (%(schema)s, %(table)s, 'reallocate', %(value)s) ON CONFLICT (table_name, table_schema, strategy) DO UPDATE SET last_partition_value = excluded.last_partition_value;

--- a/include/data_retention_retrieve_delete_policies.sql
+++ b/include/data_retention_retrieve_delete_policies.sql
@@ -4,5 +4,5 @@ SELECT QUOTE_IDENT(p.table_schema) || '.' || QUOTE_IDENT(p.table_name),
 FROM information_schema.table_partitions p
 JOIN doc.retention_policies r ON p.table_schema = r.table_schema
   AND p.table_name = r.table_name
-  AND p.values[r.partition_column] < '{date}'::TIMESTAMP - (r.retention_period || ' days')::INTERVAL
+  AND p.values[r.partition_column] < %(day)s::TIMESTAMP - (r.retention_period || ' days')::INTERVAL
 WHERE r.strategy = 'delete';

--- a/include/data_retention_retrieve_reallocate_policies.sql
+++ b/include/data_retention_retrieve_reallocate_policies.sql
@@ -8,7 +8,7 @@ SELECT QUOTE_IDENT(p.table_schema),
 FROM information_schema.table_partitions p
 JOIN doc.retention_policies r ON p.table_schema = r.table_schema
   AND p.table_name = r.table_name
-  AND p.values[r.partition_column] < '{date}'::TIMESTAMP - (r.retention_period || ' days')::INTERVAL
+  AND p.values[r.partition_column] < %(day)s::TIMESTAMP - (r.retention_period || ' days')::INTERVAL
 LEFT JOIN doc.retention_policy_tracking t ON t.table_schema = p.table_schema
   AND t.table_name = p.table_name
 WHERE r.strategy = 'reallocate'

--- a/include/data_retention_retrieve_snapshot_policies.sql
+++ b/include/data_retention_retrieve_snapshot_policies.sql
@@ -8,5 +8,5 @@ SELECT p.table_schema,
 FROM information_schema.table_partitions p
 JOIN doc.retention_policies r ON p.table_schema = r.table_schema
   AND p.table_name = r.table_name
-  AND p.values[r.partition_column] < '{date}'::TIMESTAMP - (r.retention_period || ' days')::INTERVAL
+  AND p.values[r.partition_column] < %(day)s::TIMESTAMP - (r.retention_period || ' days')::INTERVAL
 WHERE r.strategy = 'snapshot';

--- a/include/data_retention_snapshot.sql
+++ b/include/data_retention_snapshot.sql
@@ -1,1 +1,1 @@
-CREATE SNAPSHOT {repository_name}."{table_schema}.{table_name}-{partition_value}" TABLE {table_fqn} PARTITION ({partition_column} = {partition_value}) WITH ("wait_for_completion" = true);
+CREATE SNAPSHOT {target_repository_name}."{schema}.{table}-{value}" TABLE {table_fqn} PARTITION ({column} = {value}) WITH ("wait_for_completion" = true);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.1
 apache-airflow[pandas]
 requests==2.27.1
 yfinance==0.1.70

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import setup, find_packages
 setup(
     name="crate-airflow-tutorial",
     packages=find_packages(),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
-        "apache-airflow==2.3.0",
+        "apache-airflow==2.3.1",
         "apache-airflow-providers-postgres==4.1.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.8",
     install_requires=[
-        "apache-airflow==2.2.5",
+        "apache-airflow==2.3.0",
         "apache-airflow-providers-postgres==4.1.0",
     ],
     extras_require={


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Updates to Airflow 2.3.1 and replaces all manual task invocations with dynamic task mapping.

A workaround is needed for https://github.com/apache/airflow/issues/24014 in some places.

The NYC Taxi DAG is currently not functioning due to an upstream change switching to Parquet files (https://github.com/toddwschneider/nyc-taxi-data/issues/53).

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
