### PR TITLE
parquet to csv import

### DIFF
--- a/dags/parquet_import.py
+++ b/dags/parquet_import.py
@@ -1,0 +1,66 @@
+import os
+from datetime import datetime
+from airflow.models import DAG
+from airflow.operators.python import PythonOperator
+from airflow.providers.postgres.operators.postgres import PostgresOperator
+
+def get_latest_month_year():
+	currentMonth = datetime.now().month - 1
+	currentYear = datetime.now().year
+	if currentMonth == 12:
+		currentYear = currentYear - 1
+	if currentMonth < 10:
+		currentMonth = f'0{currentMonth}'
+	return f'_{currentYear}-{currentMonth}'
+
+
+def download_from_s3_csv(ti,prefix_file:str,bucket_name: str, local_path: str) -> str:
+	latest_month_year = ti.xcom_pull(task_ids=['get_latest_month_year'])[0]
+	file_name_path = f'{local_path}{prefix_file}{latest_month_year}.csv'
+	s3_path = f's3://{bucket_name}/{prefix_file}{latest_month_year}.parquet'
+	os.system(f'parquet-tools csv "{s3_path}" > "{file_name_path}"')
+	return file_name_path
+
+def process_new_file(ti):
+	file_path = ti.xcom_pull(task_ids=['download_from_s3_csv'])[0]
+	PostgresOperator(
+        task_id=f"copy_csv",
+        postgres_conn_id="cratedb_demo_connection",
+        sql=f"""
+            COPY nyc_taxi.load_trips_staging
+            FROM '{file_path}'
+            WITH (format = 'csv', empty_string_as_null = true)
+            RETURN SUMMARY;
+            """
+    ).execute({})
+
+with DAG(
+	dag_id='parquet_to_csv_nyc_tlc',
+	schedule_interval='@monthly',
+	start_date=datetime(2022,3,1),
+	catchup=False
+) as dag:
+
+
+	task_get_latest_month_year = PythonOperator(
+		task_id='get_latest_month_year',
+		python_callable=get_latest_month_year)
+
+	task_download_from_s3_csv = PythonOperator(
+		task_id='download_from_s3_csv',
+		python_callable=download_from_s3_csv,
+		op_kwargs={
+		'bucket_name':'nyc-tlc',
+		'local_path':'/usr/local/airflow/data/',
+		'prefix_file':'trip data/yellow_tripdata'
+		})
+
+	task_process_new_file = PythonOperator(
+		task_id='process_new_file',
+		python_callable=process_new_file)
+
+	task_get_latest_month_year >> task_download_from_s3_csv
+	task_download_from_s3_csv >> task_process_new_file
+
+
+	

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4==4.11.1
 apache-airflow[pandas]
 requests==2.28.1
 yfinance==0.1.74
+parquet-tools


### PR DESCRIPTION
I created a new DAG which is composed of three tasks:
- get current month and year to compose the file name
- transform the parquet file to csv and save it locally
- copy from the local file to the table (copied this task from the nyc_taxi_dag)

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
