### PR TITLE
Apply `black` code formatting to all DAGs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lint:
-    name: Run pylint
+    name: Run black/pylint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,6 +26,9 @@ jobs:
       - name: Run pylint
         run: |
           python -m pylint dags tests include
+
+      - name: Run black
+        uses: psf/black@stable
 
   test:
     name: Run pytest

--- a/README.md
+++ b/README.md
@@ -81,17 +81,18 @@ To overcome this issue, start Astronomer without the BuildKit feature: `DOCKER_B
 
 ## Code linting
 
-Before opening a pull request, please run [pylint](https://www.pylint.org) and address all reported issues. To install pylint, run:
+Before opening a pull request, please run [pylint](https://www.pylint.org) and [black](https://github.com/psf/black). To install all dependencies, run:
 
 ```shell
 python -m pip install --upgrade -e ".[develop]"
 python -m pip install --upgrade -r requirements.txt
 ```
 
-`pylint` can be run via:
+Then run `pylint` and `black` using:
 
 ```shell
 python -m pylint dags
+python -m black .
 ```
 
 ## Testing

--- a/dags/data_retention_delete_dag.py
+++ b/dags/data_retention_delete_dag.py
@@ -14,21 +14,30 @@ from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.decorators import dag, task
 
+
 @task
 def generate_sql(policy):
     """Generate DROP statment for a given partition"""
-    return Path('include/data_retention_delete.sql') \
-        .read_text(encoding="utf-8").format(table_fqn=policy[0],
-                                            column=policy[1],
-                                            value=policy[2],
-                                           )
+    return (
+        Path("include/data_retention_delete.sql")
+        .read_text(encoding="utf-8")
+        .format(
+            table_fqn=policy[0],
+            column=policy[1],
+            value=policy[2],
+        )
+    )
+
 
 @task
 def get_policies(ds=None):
     """Retrieve all partitions effected by a policy"""
     pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
-    sql = Path('include/data_retention_retrieve_delete_policies.sql')
-    return pg_hook.get_records(sql=sql.read_text(encoding="utf-8"), parameters={"day": ds})
+    sql = Path("include/data_retention_retrieve_delete_policies.sql")
+    return pg_hook.get_records(
+        sql=sql.read_text(encoding="utf-8"), parameters={"day": ds}
+    )
+
 
 @dag(
     start_date=pendulum.datetime(2021, 11, 19, tz="UTC"),

--- a/dags/financial_data_dag.py
+++ b/dags/financial_data_dag.py
@@ -18,16 +18,17 @@ import pandas as pd
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.decorators import dag, task
 
+
 def get_sp500_ticker_symbols():
     """Extracts S&P 500 companies' tickers from the S&P 500's wikipedia page"""
 
     # Getting the html code from S&P 500 wikipedia page
     url = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
-    r_html = requests.get(url,timeout=2.5).text
-    soup = BeautifulSoup(r_html, 'html.parser')
+    r_html = requests.get(url, timeout=2.5).text
+    soup = BeautifulSoup(r_html, "html.parser")
 
     # The stock tickers are found in a table in the wikipedia page,
-    # whose html "id" attribute is "constituents". Here, the html
+    # whose html "id" attribute is "constituents". Here, the html
     # soup is filtered to get the  table contents
     table_content = soup.find(id="constituents")
 
@@ -40,36 +41,50 @@ def get_sp500_ticker_symbols():
     # each stock and replace, when given, a '.' (wikipedia notation)
     # with a '-' (yfinance notation).
     # Finally, the map is returned as a list.
-    return list(map(lambda stock: stock.find('td').text.strip().replace('.', '-'),
-                    table_content.find_all('tr')[1:]))
+    return list(
+        map(
+            lambda stock: stock.find("td").text.strip().replace(".", "-"),
+            table_content.find_all("tr")[1:],
+        )
+    )
+
 
 @task(execution_timeout=datetime.timedelta(minutes=3))
 def download_yfinance_data(ds=None):
     """Downloads Adjusted Close data from S&P 500 companies"""
 
     tickers = get_sp500_ticker_symbols()
-    data = yf.download(tickers, start=ds)['Adj Close']
+    data = yf.download(tickers, start=ds)["Adj Close"]
     return data.to_json()
+
 
 @task(execution_timeout=datetime.timedelta(minutes=3))
 def prepare_data(string_data):
     """Creates a list of dictionaries with clean data values"""
 
     # transforming to dataframe for easier manipulation
-    df = pd.DataFrame.from_dict(json.loads(string_data), orient='index')
+    df = pd.DataFrame.from_dict(json.loads(string_data), orient="index")
 
     values_dict = []
     for col, closing_date in enumerate(df.columns):
         for row, ticker in enumerate(df.index):
             adj_close = df.iloc[row, col]
 
-            if not(adj_close is None or math.isnan(adj_close)):
+            if not (adj_close is None or math.isnan(adj_close)):
                 values_dict.append(
-                    {'closing_date': closing_date, 'ticker': ticker, 'adj_close': adj_close}
+                    {
+                        "closing_date": closing_date,
+                        "ticker": ticker,
+                        "adj_close": adj_close,
+                    }
                 )
             else:
-                logging.info("Skipping %s for %s, invalid adj_close (%s)",
-                             ticker, closing_date, adj_close)
+                logging.info(
+                    "Skipping %s for %s, invalid adj_close (%s)",
+                    ticker,
+                    closing_date,
+                    adj_close,
+                )
 
     return values_dict
 
@@ -93,5 +108,6 @@ def financial_data_import():
             ON CONFLICT (closing_date, ticker) DO UPDATE SET adjusted_close = excluded.adjusted_close
             """,
     ).expand(parameters=prepared_data)
+
 
 financial_data_dag = financial_data_import()

--- a/dags/table_export_dag.py
+++ b/dags/table_export_dag.py
@@ -19,9 +19,9 @@ from include.table_exports import TABLES
     catchup=False,
 )
 def table_export():
-    start = EmptyOperator(task_id='start')
-    end = EmptyOperator(task_id='end')
-    with TaskGroup(group_id='table_exports') as tg1:
+    start = EmptyOperator(task_id="start")
+    end = EmptyOperator(task_id="end")
+    with TaskGroup(group_id="table_exports") as tg1:
         for export_table in TABLES:
             PostgresOperator(
                 task_id=f"copy_{export_table['table']}",
@@ -31,13 +31,14 @@ def table_export():
                         TO DIRECTORY 's3://{{params.access}}:{{params.secret}}@{{params.target_bucket}}-{{macros.ds_add(ds, -1)}}';
                     """,
                 params={
-                    "table": export_table['table'],
-                    "timestamp_column": export_table['timestamp_column'],
-                    "target_bucket": export_table['target_bucket'],
+                    "table": export_table["table"],
+                    "timestamp_column": export_table["timestamp_column"],
+                    "target_bucket": export_table["target_bucket"],
                     "access": os.environ.get("ACCESS_KEY_ID"),
                     "secret": os.environ.get("SECRET_ACCESS_KEY"),
-                }
+                },
             )
     chain(start, tg1, end)
+
 
 table_export_dag = table_export()

--- a/include/table_exports.py
+++ b/include/table_exports.py
@@ -3,6 +3,6 @@ TABLES = [
     {
         "table": "telegraf.metrics",
         "timestamp_column": "timestamp",
-        "target_bucket": "crate-astro-tutorial/metrics"
+        "target_bucket": "crate-astro-tutorial/metrics",
     }
 ]

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,7 @@ setup(
         "apache-airflow-providers-postgres==5.2.0",
     ],
     extras_require={
-        "develop": [
-            "pylint==2.15.2"
-        ],
-        "testing": [
-            "pytest==7.1.3",
-        ],
+        "develop": ["pylint==2.15.2", "black==22.8.0"],
+        "testing": ["pytest==7.1.3"],
     },
 )

--- a/tests/dag_import_test.py
+++ b/tests/dag_import_test.py
@@ -3,5 +3,5 @@ from airflow.models import DagBag
 
 # Verifies that all DAGs can be loaded successfully
 def test_no_import_errors():
-    dag_bag = DagBag(dag_folder='dags', include_examples=False)
+    dag_bag = DagBag(dag_folder="dags", include_examples=False)
     assert len(dag_bag.import_errors) == 0, "No Import Failures"


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
As we started using `black` for the latest Data Quality Checks DAG, this applies changes proposed by `black` also to other DAGs.

There seems to be some overlap between `black` and `pylint`, but from what the documentation says, they are [commonly used together](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html) - so apparently, that makes sense.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
