### PR TITLE
apache-airflow-providers-common-sql: Fix subquery alias issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ beautifulsoup4==4.11.1
 apache-airflow[pandas]
 requests>=2.28.0
 yfinance==0.1.74
-apache-airflow-providers-common-sql>=1.1.0
+apache-airflow-providers-common-sql>=1.2.0
 apache-airflow-providers-amazon==5.0.0
 apache-airflow-providers-slack


### PR DESCRIPTION
apache-airflow-providers-common-sql finally has a new release that fixes the SQLTableCheckOperator.

From the [changelog](https://airflow.apache.org/docs/apache-airflow-providers-common-sql/1.2.0/index.html#changelog):
> ### Bug Fixes
> * Fix (and test) SQLTableCheckOperator on postgresql (#25821)

## Summary of the changes / Why this is an improvement


## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
