### PR TITLE
Move `apache-airflow-providers-postgres` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ yfinance==0.1.74
 apache-airflow-providers-common-sql>=1.2.0
 apache-airflow-providers-amazon==5.1.0
 apache-airflow-providers-slack
+apache-airflow-providers-postgres>=5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-beautifulsoup4==4.11.1
+apache-airflow-providers-amazon==5.1.0
+apache-airflow-providers-common-sql>=1.2.0
+apache-airflow-providers-postgres>=5.2.1
+apache-airflow-providers-slack
 apache-airflow[pandas]
+beautifulsoup4==4.11.1
 requests>=2.28.0
 yfinance==0.1.74
-apache-airflow-providers-common-sql>=1.2.0
-apache-airflow-providers-amazon==5.1.0
-apache-airflow-providers-slack
-apache-airflow-providers-postgres>=5.2.1

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,7 @@ setup(
     name="crate-airflow-tutorial",
     packages=find_packages(),
     python_requires=">=3.9",
-    install_requires=[
-        "apache-airflow==2.4.0",
-        "apache-airflow-providers-postgres==5.2.1",
-    ],
+    install_requires=["apache-airflow==2.4.0"],
     extras_require={
         "develop": ["pylint==2.15.2", "black==22.8.0"],
         "testing": ["pytest==7.1.3"],


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
As per feedback on Slack. We had it in `setup.py` anyways for running `pytest`/`pylint` (which run outside the `astro-runtime` containers).
Moving the dependency to `requirements.txt` makes it more explicit, not depending anymore on the `astro-runtime` packaging.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
