### PR TITLE
Airflow 2.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/astro-runtime:7.0.0
+FROM quay.io/astronomer/astro-runtime:7.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/astro-runtime:6.0.4
+FROM quay.io/astronomer/astro-runtime:7.0.0

--- a/dags/data_retention_delete_dag.py
+++ b/dags/data_retention_delete_dag.py
@@ -10,7 +10,7 @@ See the file setup/data_retention_schema.sql in this repository.
 """
 from pathlib import Path
 import pendulum
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.decorators import dag, task
 
@@ -47,9 +47,9 @@ def get_policies(ds=None):
 def data_retention_delete():
     sql_statements = generate_sql.expand(policy=get_policies())
 
-    PostgresOperator.partial(
+    SQLExecuteQueryOperator.partial(
         task_id="delete_partition",
-        postgres_conn_id="cratedb_connection",
+        conn_id="cratedb_connection",
     ).expand(sql=sql_statements)
 
 

--- a/dags/data_retention_reallocate_dag.py
+++ b/dags/data_retention_reallocate_dag.py
@@ -10,7 +10,7 @@ See the file setup/data_retention_schema.sql in this repository.
 """
 from pathlib import Path
 import pendulum
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.decorators import dag, task
 
@@ -58,14 +58,14 @@ def generate_sql_reallocate(policy):
 def data_retention_reallocate():
     policies = map_policy.expand(policy=get_policies())
 
-    reallocate = PostgresOperator.partial(
+    reallocate = SQLExecuteQueryOperator.partial(
         task_id="reallocate_partitions",
-        postgres_conn_id="cratedb_connection",
+        conn_id="cratedb_connection",
     ).expand(sql=generate_sql_reallocate.expand(policy=policies))
 
-    track = PostgresOperator.partial(
+    track = SQLExecuteQueryOperator.partial(
         task_id="add_tracking_information",
-        postgres_conn_id="cratedb_connection",
+        conn_id="cratedb_connection",
         sql="data_retention_reallocate_tracking.sql",
     ).expand(parameters=policies)
 

--- a/dags/data_retention_snapshot_dag.py
+++ b/dags/data_retention_snapshot_dag.py
@@ -18,7 +18,7 @@ from airflow.decorators import dag, task
 @task
 def get_policies(ds=None):
     """Retrieve all partitions effected by a policy"""
-    pg_hook = PostgresHook(conn_id="cratedb_connection")
+    pg_hook = PostgresHook(postgres_conn_id="cratedb_connection")
     sql = Path("include/data_retention_retrieve_snapshot_policies.sql")
     return pg_hook.get_records(
         sql=sql.read_text(encoding="utf-8"), parameters={"day": ds}

--- a/dags/financial_data_dag.py
+++ b/dags/financial_data_dag.py
@@ -15,7 +15,7 @@ import requests
 from bs4 import BeautifulSoup
 import yfinance as yf
 import pandas as pd
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.decorators import dag, task
 
 
@@ -99,9 +99,9 @@ def financial_data_import():
 
     prepared_data = prepare_data(yfinance_data)
 
-    PostgresOperator.partial(
+    SQLExecuteQueryOperator.partial(
         task_id="insert_data_task",
-        postgres_conn_id="cratedb_connection",
+        conn_id="cratedb_connection",
         sql="""
             INSERT INTO doc.sp500 (closing_date, ticker, adjusted_close)
             VALUES (%(closing_date)s, %(ticker)s, %(adj_close)s)

--- a/dags/nyc_taxi_dag.py
+++ b/dags/nyc_taxi_dag.py
@@ -24,7 +24,7 @@ from airflow.decorators import task, dag
 from airflow.models.baseoperator import chain
 
 from airflow.operators.bash import BashOperator
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.amazon.aws.transfers.local_to_s3 import (
     LocalFilesystemToS3Operator,
 )
@@ -75,9 +75,9 @@ def taskflow():
         replace=True,
     )
 
-    copy_csv_staging = PostgresOperator(
+    copy_csv_staging = SQLExecuteQueryOperator(
         task_id="copy_csv_staging",
-        postgres_conn_id="cratedb_demo_connection",
+        conn_id="cratedb_demo_connection",
         sql=f"""
                 COPY nyc_taxi.load_trips_staging
                 FROM 's3://{ACCESS_KEY_ID}:{SECRET_ACCESS_KEY}@{S3_BUCKET}{formatted_file_date}.csv' 
@@ -86,15 +86,15 @@ def taskflow():
             """,
     )
 
-    copy_staging_to_trips = PostgresOperator(
+    copy_staging_to_trips = SQLExecuteQueryOperator(
         task_id="copy_staging_to_trips",
-        postgres_conn_id="cratedb_demo_connection",
+        conn_id="cratedb_demo_connection",
         sql=Path("include/taxi-insert.sql").read_text(encoding="utf-8"),
     )
 
-    delete_staging = PostgresOperator(
+    delete_staging = SQLExecuteQueryOperator(
         task_id="delete_staging",
-        postgres_conn_id="cratedb_demo_connection",
+        conn_id="cratedb_demo_connection",
         sql="DELETE FROM nyc_taxi.load_trips_staging;",
     )
 

--- a/dags/table_export_dag.py
+++ b/dags/table_export_dag.py
@@ -6,7 +6,7 @@ A detailed tutorial is available at https://community.crate.io/t/cratedb-and-apa
 import os
 import pendulum
 from airflow.decorators import dag, task_group
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.operators.empty import EmptyOperator
 from airflow.models.baseoperator import chain
 from include.table_exports import TABLES
@@ -15,9 +15,9 @@ from include.table_exports import TABLES
 @task_group
 def export_tables():
     for export_table in TABLES:
-        PostgresOperator(
+        SQLExecuteQueryOperator(
             task_id=f"copy_{export_table['table']}",
-            postgres_conn_id="cratedb_connection",
+            conn_id="cratedb_connection",
             sql="""
                     COPY {{params.table}} WHERE DATE_TRUNC('day', {{params.timestamp_column}}) = '{{macros.ds_add(ds, -1)}}'
                     TO DIRECTORY 's3://{{params.access}}:{{params.secret}}@{{params.target_bucket}}-{{macros.ds_add(ds, -1)}}';

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 apache-airflow-providers-amazon==6.2.0
-apache-airflow-providers-common-sql>=1.2.0
+apache-airflow-providers-common-sql>=1.3.1
 apache-airflow-providers-postgres>=5.2.1
 apache-airflow-providers-slack
 apache-airflow[pandas]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 apache-airflow-providers-amazon==6.2.0
 apache-airflow-providers-common-sql>=1.3.1
-apache-airflow-providers-postgres>=5.2.1
+apache-airflow-providers-postgres>=5.3.1
 apache-airflow-providers-slack
 apache-airflow[pandas]
 beautifulsoup4==4.11.1
 requests>=2.28.0
 yfinance==0.1.87
 parquet-tools
-

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="crate-airflow-tutorial",
     packages=find_packages(),
     python_requires=">=3.9",
-    install_requires=["apache-airflow==2.4.3"],
+    install_requires=["apache-airflow==2.5.0"],
     extras_require={
         "develop": ["pylint==2.15.7", "black==22.10.0"],
         "testing": ["pytest==7.2.0"],


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Upgrade from Airflow 2.4.3 (the Airflow version is implicitly set by the `astro-runtime` environment, see https://docs.astronomer.io/astro/runtime-release-notes).

The main difference is that `airflow.providers.postgres.operators.postgres.PostgresOperator` got replaced by `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`. Through the connection type passed through `conn_id`, Airflow now dynamically chooses the right database-specific operator in the background automatically. Usage of the `PostgresOperator` directly causes a deprecation warning.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
